### PR TITLE
Problem mit falscher Sortierung der Meta-Felder behoben

### DIFF
--- a/plugins/auth/install.inc.php
+++ b/plugins/auth/install.inc.php
@@ -13,7 +13,7 @@ $a = rex_sql::factory();
 $a->setTable("rex_62_params");
 $a->setValue("title","translate:com_permtype");
 $a->setValue("name","art_com_permtype");
-$a->setValue("prior","11");
+$a->setValue("prior","100");
 $a->setValue("type","3");
 $a->setValue("params","0:translate:com_perm_all|1:translate:com_perm_only_logged_in|2:translate:com_perm_only_not_logged_in");
 $a->setValue("validate",NULL);
@@ -32,6 +32,9 @@ $g->setQuery('show columns from rex_article like "art_com_permtype"');
 if ($g->getRows()==0) {
 	$a->setQuery("ALTER TABLE `rex_article` ADD `art_com_permtype` VARCHAR( 255 ) NOT NULL"); 
 }
+
+## Prio neu sortieren // Metainfo
+rex_organize_priorities($REX['TABLE_PREFIX']. '62_params', 'prior', 'name LIKE "art_%"', 'prior, updatedate', 'field_id');
 
 // ************************************************************** CACHE LOESCHEN
 

--- a/plugins/group/install.inc.php
+++ b/plugins/group/install.inc.php
@@ -6,12 +6,19 @@
  * @author <a href="http://www.yakamara.de">www.yakamara.de</a>
  */
 
+$REX['ADDON']['install']['group'] = 1;
+
+## Wegen Bug erst ab REX5 nutzbar 
+//a62_add_field($title,							$name,					$prior,	$attributes, 			$type, 	$default, 	$params = null,																															$validate = null,	$restrictions = '')
+//a62_add_field('translate:com_group_perm', 	'art_com_grouptype', 	100,	'',						3,		'',			'0:translate:com_group_forallgroups|1:translate:com_group_inallgroups|2:translate:com_group_inonegroup|3:translate:com_group_nogroups',	'',					'');
+//a62_add_field('translate:com_group_name', 	'art_com_groups', 		101, 	'multiple=multiple', 	3, 		'', 		'select name as label,id from rex_com_group order by label',																			'',					'');
+
 // ----- Art der Gruppenrechte
 $a = new rex_sql;
 $a->setTable("rex_62_params");
 $a->setValue("title","translate:com_group_perm");
 $a->setValue("name","art_com_grouptype");
-$a->setValue("prior","10");
+$a->setValue("prior","100");
 $a->setValue("type","3");
 $a->setValue("params","0:translate:com_group_forallgroups|1:translate:com_group_inallgroups|2:translate:com_group_inonegroup|3:translate:com_group_nogroups");
 $a->setValue("validate",NULL);
@@ -26,9 +33,9 @@ if ($g->getRows()==1) {
 }
 $g = new rex_sql;
 $g->setQuery('show columns from rex_article Like "art_com_grouptype"');
-if ($g->getRows()==0) 
+if ($g->getRows()==0)
 {
-	$a->setQuery("ALTER TABLE `rex_article` ADD `art_com_grouptype` VARCHAR( 255 ) NOT NULL"); 
+	$a->setQuery("ALTER TABLE `rex_article` ADD `art_com_grouptype` VARCHAR( 255 ) NOT NULL");
 }
 
 // ----- Gruppen
@@ -36,7 +43,7 @@ $a = new rex_sql;
 $a->setTable("rex_62_params");
 $a->setValue("title","translate:com_group_name");
 $a->setValue("name","art_com_groups");
-$a->setValue("prior","12");
+$a->setValue("prior","101");
 $a->setValue("type","3");
 $a->setValue("attributes","multiple=multiple");
 $a->setValue("params","select name as label,id from rex_com_group order by label");
@@ -53,13 +60,14 @@ if ($g->getRows()==1) {
 $g = new rex_sql;
 $g->setQuery('show columns from rex_article Like "art_com_groups"');
 if ($g->getRows()==0) {
-	$a->setQuery("ALTER TABLE `rex_article` ADD `art_com_groups` VARCHAR( 255 ) NOT NULL"); 
+	$a->setQuery("ALTER TABLE `rex_article` ADD `art_com_groups` VARCHAR( 255 ) NOT NULL");
 }
 
-$REX['ADDON']['install']['group'] = 1;
+## Prio neu sortieren // Metainfo
+rex_organize_priorities($REX['TABLE_PREFIX']. '62_params', 'prior', 'name LIKE "art_%"', 'prior, updatedate', 'field_id');
+
 $REX['ADDON']['installmsg']['group'] = ""; // $I18N->msg('community_group_install','2.8');
 
-$info = rex_generateAll(); // quasi kill cache ..
-	
+$info = rex_generateAll(); // quasi kill cache ..	
 
 ?>


### PR DESCRIPTION
Felder werden mit Prioritäten >= 100 angelegt und anschließend neu organisiert. Reihenfolge ist zwar weiterhin von der Installationsreihenfolge abhängig, Felder bleiben dafür aber wenigstens zusammen.
