### PR TITLE
fix: checkArticlePerm() -> checkPerm()

### DIFF
--- a/plugins/auth/classes/class.rex_com_navigation.inc.php
+++ b/plugins/auth/classes/class.rex_com_navigation.inc.php
@@ -222,7 +222,7 @@ class rex_com_navigation extends rex_navigation
   
   function _checkPerm($nav,$level)
   {
-    return rex_com_auth::checkArticlePerm($nav);
+    return rex_com_auth::checkPerm($nav);
   }
   
   


### PR DESCRIPTION
Beim install des COM dumps von redaxo.org in ne 4.3.4 mit aktueller COM und XFORM von Github hats wg. dem alten/falschen Methodennamen nen fatal geworfen.. fix kommt über Markus L. - sollt somit passen denk ich.
