### PR TITLE
EP auf 'REX_EXTENSION_EARLY' gestellt

### DIFF
--- a/plugins/auth/config.inc.php
+++ b/plugins/auth/config.inc.php
@@ -57,7 +57,7 @@ if ($REX['REDAXO']) {
 
 if ($REX['ADDON']['community']['plugin_auth']['auth_active'] == 1) {
   if (!$REX['REDAXO']) {
-    rex_register_extension('ADDONS_INCLUDED', 'rex_com_auth_config');
+    rex_register_extension('ADDONS_INCLUDED', 'rex_com_auth_config', array(), REX_EXTENSION_EARLY);
     function rex_com_auth_config($params)
     {
       global $REX, $I18N;


### PR DESCRIPTION
Damit die Variable $REX['COM_USER'] gesetzt ist wenn der EP IMAGE_MANAGER_INIT aufgerufen wird, sonst funktioniert auth_media nicht.