### PR TITLE
Sicherstellen, dass der Ausgabepuffer leer ist.

### DIFF
--- a/plugins/auth_media/classes/class.rex_com_auth_media.inc.php
+++ b/plugins/auth_media/classes/class.rex_com_auth_media.inc.php
@@ -40,7 +40,8 @@ class rex_com_auth_media
         header('Content-Type: application/download');
         header('Content-Disposition: attachment; filename=' . $media->getFileName() . ';');
       }
-
+      ob_clean();
+      flush();
       @readfile($media->getFullPath());
     }
 


### PR DESCRIPTION
Wenn versehentlich schon eine Ausgabe vor dem Senden der Datei stattgefunden hat, kommt die Datei zerstört an. Mit dem leeren des Ausgabepuffers wird die Übertragung etwas robuster. Ich habe diese Variante von Rexdudes seo42 übernommen.