### PR TITLE
Remove $_REQUEST from log when login with Login/Password combination failed.

### DIFF
--- a/plugins/auth/lib/ycom_auth.php
+++ b/plugins/auth/lib/ycom_auth.php
@@ -275,7 +275,6 @@ class rex_ycom_auth
                     [
                         'EXCEPTION' => $e->getMessage(),
                         'SERVER' => $_SERVER,
-                        'REQUEST' => $_REQUEST,
                     ],
                 );
             }


### PR DESCRIPTION
Since the password is in the $_REQUEST during a failed login attempt it should not be saved.